### PR TITLE
Switch to @Configuration-based auto-config

### DIFF
--- a/META-INF/spring.factories
+++ b/META-INF/spring.factories
@@ -1,1 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.sonatype.licensing.product.internal.LicenseKeyAutoConfiguration

--- a/org/sonatype/licensing/product/internal/LicenseKeyAutoConfiguration.java
+++ b/org/sonatype/licensing/product/internal/LicenseKeyAutoConfiguration.java
@@ -7,10 +7,10 @@ import org.sonatype.licensing.feature.Feature;
 import org.sonatype.licensing.feature.Features;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Bean;
-import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
 
-@AutoConfiguration
+@Configuration
 public class LicenseKeyAutoConfiguration {
 
     @Bean

--- a/pom.xml
+++ b/pom.xml
@@ -87,9 +87,10 @@
             <artifactId>org.eclipse.sisu.plexus</artifactId>
             <version>0.9.0.M4</version>
         </dependency>
-        <dependency><groupId>org.springframework.boot</groupId>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
-            <version>3.3.6</version>
+            <version>2.7.18</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -99,7 +100,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
-            <version>3.3.4</version>
+            <version>2.7.18</version>
         </dependency>
         <!-- при необходимости добавьте прочие библиотеки -->
     </dependencies>


### PR DESCRIPTION
## Summary
- replace `@AutoConfiguration` with standard `@Configuration`
- register auto-configuration using `META-INF/spring.factories`
- align Spring Boot dependencies with 2.7.x line

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68922bf6635083319eb83d23a5d092c2